### PR TITLE
fix: switch GitHub url bottom nav to open in webview and not external browser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.kt]
+ktlint_standard_function-name-case = disabled
+ktlint_function_naming = disabled

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS file assigns ownership of specific files/paths to users or teams.
+# Designated owners are auto-requested for review on PRs modifying these areas.
+
+* @michaeltchuang

--- a/composeTestApp/src/commonMain/kotlin/co/algorand/app/ui/screens/DiscoverScreen.kt
+++ b/composeTestApp/src/commonMain/kotlin/co/algorand/app/ui/screens/DiscoverScreen.kt
@@ -11,7 +11,7 @@ import androidx.navigation.NavController
 import co.algorand.app.ui.widgets.snackbar.SnackbarViewModel
 import co.algorand.app.utils.Constants.REPO_URL
 import com.michaeltchuang.walletsdk.designsystem.theme.AlgoKitTheme
-import com.michaeltchuang.walletsdk.webview.AlgoKitWebViewPlatformScreen
+import com.michaeltchuang.walletsdk.webview.AlgoKitWebViewScreen
 
 @Composable
 fun DiscoverScreen(
@@ -27,6 +27,9 @@ fun DiscoverScreen(
                 .fillMaxSize()
                 .background(AlgoKitTheme.colors.background),
     ) {
-        AlgoKitWebViewPlatformScreen(REPO_URL)
+        AlgoKitWebViewScreen(
+            modifier = Modifier.fillMaxSize(),
+            REPO_URL,
+        )
     }
 }


### PR DESCRIPTION
## Summary
 - Switch GitHub url bottom nav to open in webview and not external browser

## Testing Plan
 - [X] Was this tested locally? If not, explain why

## Additional Info
 - Screenshots/Recordings

<img width="200" alt="Simulator Screenshot - iPhone 16 - 2025-08-31 at 12 27 29" src="https://github.com/user-attachments/assets/ae7d18ff-4a03-4384-b916-3d3e35f878bc" />
